### PR TITLE
Update StripeGateway.php

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -503,6 +503,7 @@ class StripeGateway {
 				->setLastFourCardDigits($this->getLastFourCardDigits($customer))
 				->setStripeIsActive(true)
 				->setSubscriptionEndDate(null)
+				->setTrialEndDate($this->getTrialEndForUpdate())
 				->saveBillableInstance();
 	}
 


### PR DESCRIPTION
We have two subscriptions, hold and standard.
When you go to the hold subscription, you are still charged for the whole month, and should have access to the site until the end of the month.

        // change to the hold subscription
        $user->subscription("hold")
            // but charge them for the whole month anyway
            ->noProrate()
            // and give them some trial time until that month runs out
            ->trialFor(new \DateTime(date("Y-m-d", strtotime("first day of next month"))))
            // swap this out for the old plan
            ->swap();

Stripe got the notice and started the trial, my database did not.
This fixes the issue for my purposes.